### PR TITLE
Completed notation implementation

### DIFF
--- a/src/game/moving.rs
+++ b/src/game/moving.rs
@@ -3,7 +3,7 @@ use super::game::*;
 //use super::rules::*;
 
 pub struct MoveError {
-    reason: String
+    //reason: String
 }
 
 // given a Game (containing moves), validates the next move and returns either the resulting Game or
@@ -11,6 +11,7 @@ pub struct MoveError {
 pub fn make_move_internal(game: &Game, next_move: String) -> Result<Game, MoveError> {
 
     // mot implemented - just always accepts whatever is passed in as the new move and preserves the previous game state
+
     let mut moves = game.moves.clone();
     moves.push(next_move);
     Ok(Game {

--- a/src/game/notation.rs
+++ b/src/game/notation.rs
@@ -92,12 +92,9 @@ fn process_coordinates(notation: &str) -> (Option<u8>, Option<u8>, &str) {
     // destination is always file, rank
     let mut chars = notation.chars().rev();
     let rank_char = chars.nth(0);
-println!(">>{}<<", notation);
     let (rank, without_rank) = parse_and_trim_coordinate_suffix(rank_char, notation, 10, 1);
-println!(">>{}<<", without_rank);
     let file_char = if rank.is_some() { chars.nth(0) } else { rank_char };
     let (file, without_file_and_rank) = parse_and_trim_coordinate_suffix(file_char, without_rank, 18, 10);
-println!(">>{}<<", without_file_and_rank);
     (rank, file, without_file_and_rank)
 }
 
@@ -158,11 +155,8 @@ pub fn decode(notation: String) -> Notation {
     let (promoted_to_piece_type, ex_promotion) = process_promotion(ex_castling);
     let (rank, file, ex_destination) = process_coordinates(ex_promotion);
     let (capture, ex_capture) = process_capture(ex_destination);
-println!(">{}<", ex_destination);
     let (piece_type, ex_piece_type) = process_piece_type(ex_capture);
-println!(">{}<", ex_capture);
     let (source_rank, source_file, ex_source_coordinates) = process_coordinates(ex_piece_type);
-println!(">{}<", ex_source_coordinates);
     match ex_source_coordinates {
         "" => {
             let parsed = Notation {

--- a/src/game/position.rs
+++ b/src/game/position.rs
@@ -1,5 +1,5 @@
 use super::piece_type::*;
-use super::notation::*;
+//use super::notation::*;
 use std::vec::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -63,7 +63,7 @@ pub fn calculate_positions(moves: Vec<String>) -> Vec<Position> {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
+    //use super::*;
 
     // #[test]
     // fn a_single_move() {

--- a/src/game/rules/rules_1_2_who_s_go_is_it.rs
+++ b/src/game/rules/rules_1_2_who_s_go_is_it.rs
@@ -6,7 +6,7 @@ then the players move alternately, with the player with the dark-coloured pieces
 use crate::game::game::*;
 use crate::game::moving::*;
 
-pub fn validate(game: &Game, next_move: String) -> Result<(), MoveError> {
+pub fn validate(_game: &Game, _next_move: String) -> Result<(), MoveError> {
     Ok(())
 }
 


### PR DESCRIPTION
This is intended to be the complete implementation of notation parsing. It should parse any legal notation as described here: https://en.wikipedia.org/wiki/Algebraic_notation_(chess)

Could you try and verify that what is described in that document matches the tests specified in notation.rs?

Note that you may find it easier to just read the file rather than the diff: https://github.com/goofballLogic/narmi-chess/blob/7e10a4d0b8a4a0015bd668e09fac34d9bd120932/src/game/notation.rs#L185